### PR TITLE
Custom output stream support

### DIFF
--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/DefaultFileWriter.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/DefaultFileWriter.kt
@@ -1,0 +1,32 @@
+package com.akexorcist.library.filewritercompat.core
+
+import com.akexorcist.library.filewritercompat.core.utility.FileHelper
+import java.io.File
+import java.io.FileOutputStream
+import java.io.ObjectOutputStream
+
+object DefaultFileWriter {
+    val ByteArrayWriter = { data: ByteArray, file: File ->
+        FileHelper.writeFile(data, file)
+    }
+
+    val StringWriter = { data: String, file: File ->
+        if (!file.exists()) {
+            file.createNewFile()
+        }
+        val fos = FileOutputStream(file)
+        ObjectOutputStream(fos).use {
+            it.writeBytes(data)
+        }
+    }
+
+    val AnyWriter = { data: Any, file: File ->
+        if (!file.exists()) {
+            file.createNewFile()
+        }
+        val fos = FileOutputStream(file)
+        ObjectOutputStream(fos).use {
+            it.writeObject(data)
+        }
+    }
+}

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/WriteExecutor.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/WriteExecutor.kt
@@ -4,7 +4,7 @@ import androidx.fragment.app.FragmentActivity
 import java.io.File
 
 interface WriteExecutor<SUCCESS, ERROR> {
-    suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<SUCCESS, ERROR>
+    suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: suspend (DATA, File) -> Unit): FileResult<SUCCESS, ERROR>
 
     suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<SUCCESS, ERROR> {
         return write(activity, data, DefaultFileWriter.ByteArrayWriter)

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/WriteExecutor.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/WriteExecutor.kt
@@ -3,6 +3,7 @@ package com.akexorcist.library.filewritercompat.core
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
 
-interface FileWriter<SUCCESS : Uri, ERROR> {
+interface WriteExecutor<SUCCESS : Uri, ERROR> {
     suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ERROR>
 }
+

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/WriteExecutor.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/WriteExecutor.kt
@@ -1,9 +1,20 @@
 package com.akexorcist.library.filewritercompat.core
 
-import android.net.Uri
 import androidx.fragment.app.FragmentActivity
+import java.io.File
 
-interface WriteExecutor<SUCCESS : Uri, ERROR> {
-    suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ERROR>
+interface WriteExecutor<SUCCESS, ERROR> {
+    suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<SUCCESS, ERROR>
+
+    suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<SUCCESS, ERROR> {
+        return write(activity, data, DefaultFileWriter.ByteArrayWriter)
+    }
+
+    suspend fun write(activity: FragmentActivity, data: String): FileResult<SUCCESS, ERROR> {
+        return write(activity, data, DefaultFileWriter.StringWriter)
+    }
+
+    suspend fun write(activity: FragmentActivity, data: Any): FileResult<SUCCESS, ERROR> {
+        return write(activity, data, DefaultFileWriter.AnyWriter)
+    }
 }
-

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificCache.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificCache.kt
@@ -2,7 +2,7 @@ package com.akexorcist.library.filewritercompat.core.manager
 
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
-import com.akexorcist.library.filewritercompat.core.FileWriter
+import com.akexorcist.library.filewritercompat.core.WriteExecutor
 import com.akexorcist.library.filewritercompat.core.FileResult
 import com.akexorcist.library.filewritercompat.core.utility.FileHelper
 import java.io.File
@@ -33,16 +33,16 @@ class ExternalAppSpecificCache {
             this.childPath = childPath
         }
 
-        fun build(): FileWriter<Uri, ErrorReason> = Writer(
+        fun build(): WriteExecutor<Uri, ErrorReason> = Executor(
             childPath = childPath ?: "",
             fileNameWithExtension = fileNameWithExtension,
         )
     }
 
-    class Writer(
+    class Executor(
         private val childPath: String,
         private val fileNameWithExtension: String,
-    ) : FileWriter<Uri, ErrorReason> {
+    ) : WriteExecutor<Uri, ErrorReason> {
         override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificCache.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificCache.kt
@@ -43,7 +43,7 @@ class ExternalAppSpecificCache {
         private val childPath: String,
         private val fileNameWithExtension: String,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }
@@ -54,7 +54,7 @@ class ExternalAppSpecificCache {
             }
             val file = File(directory, fileNameWithExtension)
             return try {
-                FileHelper.writeFile(data, file)
+                writer(data, file)
                 FileResult.Success(Uri.fromFile(file))
             } catch (e: Exception) {
                 FileResult.Error(ErrorReason.CannotWriteFile(e))

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificCache.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificCache.kt
@@ -43,7 +43,7 @@ class ExternalAppSpecificCache {
         private val childPath: String,
         private val fileNameWithExtension: String,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: suspend (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificFile.kt
@@ -2,7 +2,7 @@ package com.akexorcist.library.filewritercompat.core.manager
 
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
-import com.akexorcist.library.filewritercompat.core.FileWriter
+import com.akexorcist.library.filewritercompat.core.WriteExecutor
 import com.akexorcist.library.filewritercompat.core.FileResult
 import com.akexorcist.library.filewritercompat.core.utility.FileHelper
 import java.io.File
@@ -44,18 +44,18 @@ class ExternalAppSpecificFile {
             this.childPath = childPath
         }
 
-        fun build(): FileWriter<Uri, ErrorReason> = Writer(
+        fun build(): WriteExecutor<Uri, ErrorReason> = Executor(
             directoryType = directoryType,
             childPath = childPath ?: "",
             fileNameWithExtension = fileNameWithExtension,
         )
     }
 
-    class Writer(
+    class Executor(
         private val directoryType: String?,
         private val childPath: String,
         private val fileNameWithExtension: String,
-    ) : FileWriter<Uri, ErrorReason> {
+    ) : WriteExecutor<Uri, ErrorReason> {
         override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificFile.kt
@@ -9,7 +9,6 @@ import java.io.File
 
 class ExternalAppSpecificFile {
     sealed class ErrorReason {
-
         @Suppress("unused")
         class InvalidFileNameWithExtension(
             val fileNameWithExtension: String
@@ -56,7 +55,7 @@ class ExternalAppSpecificFile {
         private val childPath: String,
         private val fileNameWithExtension: String,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }
@@ -70,7 +69,7 @@ class ExternalAppSpecificFile {
             }
             val file = File(directory, fileNameWithExtension)
             return try {
-                FileHelper.writeFile(data, file)
+                writer(data, file)
                 FileResult.Success(Uri.fromFile(file))
             } catch (e: Exception) {
                 FileResult.Error(ErrorReason.CannotWriteFile(e))

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalAppSpecificFile.kt
@@ -55,7 +55,7 @@ class ExternalAppSpecificFile {
         private val childPath: String,
         private val fileNameWithExtension: String,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: suspend (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalShareableFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalShareableFile.kt
@@ -3,7 +3,7 @@ package com.akexorcist.library.filewritercompat.core.manager
 import android.net.Uri
 import android.os.Environment
 import androidx.fragment.app.FragmentActivity
-import com.akexorcist.library.filewritercompat.core.FileWriter
+import com.akexorcist.library.filewritercompat.core.WriteExecutor
 import com.akexorcist.library.filewritercompat.core.permission.StoragePermissionRequest
 import com.akexorcist.library.filewritercompat.core.FileResult
 import com.akexorcist.library.filewritercompat.core.utility.FileHelper
@@ -56,7 +56,7 @@ class ExternalShareableFile {
             this.storagePermissionRequest = storagePermissionRequest
         }
 
-        fun build(): FileWriter<Uri, ErrorReason> = Writer(
+        fun build(): WriteExecutor<Uri, ErrorReason> = Executor(
             directoryType = directoryType,
             childPath = childPath ?: "",
             fileNameWithExtension = fileNameWithExtension,
@@ -64,12 +64,12 @@ class ExternalShareableFile {
         )
     }
 
-    class Writer(
+    class Executor(
         private val directoryType: String,
         private val childPath: String,
         private val fileNameWithExtension: String,
         private val storagePermissionRequest: StoragePermissionRequest,
-    ) : FileWriter<Uri, ErrorReason> {
+    ) : WriteExecutor<Uri, ErrorReason> {
         override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalShareableFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalShareableFile.kt
@@ -13,7 +13,6 @@ import java.io.File
 
 class ExternalShareableFile {
     sealed class ErrorReason {
-
         @Suppress("unused")
         class InvalidFileNameWithExtension(
             val fileNameWithExtension: String
@@ -70,7 +69,7 @@ class ExternalShareableFile {
         private val fileNameWithExtension: String,
         private val storagePermissionRequest: StoragePermissionRequest,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }
@@ -89,7 +88,7 @@ class ExternalShareableFile {
             }
             val file = File(directory, fileNameWithExtension)
             try {
-                FileHelper.writeFile(data, file)
+                writer(data, file)
             } catch (e: Exception) {
                 return FileResult.Error(ErrorReason.CannotWriteFile(e))
             }

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalShareableFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/ExternalShareableFile.kt
@@ -69,7 +69,7 @@ class ExternalShareableFile {
         private val fileNameWithExtension: String,
         private val storagePermissionRequest: StoragePermissionRequest,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: suspend (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificCache.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificCache.kt
@@ -43,7 +43,7 @@ class InternalAppSpecificCache {
         private val childPath: String,
         private val fileNameWithExtension: String,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: suspend (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificCache.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificCache.kt
@@ -2,7 +2,7 @@ package com.akexorcist.library.filewritercompat.core.manager
 
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
-import com.akexorcist.library.filewritercompat.core.FileWriter
+import com.akexorcist.library.filewritercompat.core.WriteExecutor
 import com.akexorcist.library.filewritercompat.core.FileResult
 import com.akexorcist.library.filewritercompat.core.utility.FileHelper
 import java.io.File
@@ -34,16 +34,16 @@ class InternalAppSpecificCache {
             this.childPath = childPath
         }
 
-        fun build(): FileWriter<Uri, ErrorReason> = Writer(
+        fun build(): WriteExecutor<Uri, ErrorReason> = Executor(
             childPath = childPath ?: "",
             fileNameWithExtension = fileNameWithExtension,
         )
     }
 
-    class Writer(
+    class Executor(
         private val childPath: String,
         private val fileNameWithExtension: String,
-    ) : FileWriter<Uri, ErrorReason> {
+    ) : WriteExecutor<Uri, ErrorReason> {
         override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificCache.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificCache.kt
@@ -9,7 +9,6 @@ import java.io.File
 
 class InternalAppSpecificCache {
     sealed class ErrorReason {
-
         @Suppress("unused")
         class InvalidFileNameWithExtension(
             val fileNameWithExtension: String
@@ -44,7 +43,7 @@ class InternalAppSpecificCache {
         private val childPath: String,
         private val fileNameWithExtension: String,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }
@@ -55,7 +54,7 @@ class InternalAppSpecificCache {
             }
             val file = File(directory, fileNameWithExtension)
             return try {
-                FileHelper.writeFile(data, file)
+                writer(data, file)
                 FileResult.Success(Uri.fromFile(file))
             } catch (e: Exception) {
                 FileResult.Error(ErrorReason.CannotWriteFile(e))

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificFile.kt
@@ -9,7 +9,6 @@ import java.io.File
 
 class InternalAppSpecificFile {
     sealed class ErrorReason {
-
         @Suppress("unused")
         class InvalidFileNameWithExtension(
             val fileNameWithExtension: String
@@ -44,7 +43,7 @@ class InternalAppSpecificFile {
         private var fileNameWithExtension: String,
         private var childPath: String,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }
@@ -55,7 +54,7 @@ class InternalAppSpecificFile {
             }
             val file = File(directory, fileNameWithExtension)
             return try {
-                FileHelper.writeFile(data, file)
+                writer(data, file)
                 FileResult.Success(Uri.fromFile(file))
             } catch (e: Exception) {
                 FileResult.Error(ErrorReason.CannotWriteFile(e))

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificFile.kt
@@ -43,7 +43,7 @@ class InternalAppSpecificFile {
         private var fileNameWithExtension: String,
         private var childPath: String,
     ) : WriteExecutor<Uri, ErrorReason> {
-        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
+        override suspend fun <DATA> write(activity: FragmentActivity, data: DATA, writer: suspend (DATA, File) -> Unit): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))
             }

--- a/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificFile.kt
+++ b/file-writer-compat/core/src/main/java/com/akexorcist/library/filewritercompat/core/manager/InternalAppSpecificFile.kt
@@ -2,7 +2,7 @@ package com.akexorcist.library.filewritercompat.core.manager
 
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
-import com.akexorcist.library.filewritercompat.core.FileWriter
+import com.akexorcist.library.filewritercompat.core.WriteExecutor
 import com.akexorcist.library.filewritercompat.core.FileResult
 import com.akexorcist.library.filewritercompat.core.utility.FileHelper
 import java.io.File
@@ -34,16 +34,16 @@ class InternalAppSpecificFile {
             this.childPath = childPath
         }
 
-        fun build(): FileWriter<Uri, ErrorReason> = Writer(
+        fun build(): WriteExecutor<Uri, ErrorReason> = Executor(
             childPath = childPath ?: "",
             fileNameWithExtension = fileNameWithExtension,
         )
     }
 
-    class Writer(
+    class Executor(
         private var fileNameWithExtension: String,
         private var childPath: String,
-    ) : FileWriter<Uri, ErrorReason> {
+    ) : WriteExecutor<Uri, ErrorReason> {
         override suspend fun write(activity: FragmentActivity, data: ByteArray): FileResult<Uri, ErrorReason> {
             if (!FileHelper.isValidFileNameWithExtension(fileNameWithExtension)) {
                 return FileResult.Error(ErrorReason.InvalidFileNameWithExtension(fileNameWithExtension))


### PR DESCRIPTION
Allows user to custom output stream with custom writer function. So we can support any data type depends on custom writer function 

For example 

```kotlin
val data: String = "Hello World"
val activity: FragmentActivity = /* ... */

val StringWriter = { data: String, file: File ->
    if (!file.exists()) {
        file.createNewFile()
    }
    val fos = FileOutputStream(file)
    ObjectOutputStream(fos).use {
        it.writeBytes(data)
    }
}

FileWriterCompat.Builder.createExternalAppSpecificCache(
    fileNameWithExtension = fileName,
)
    .build()
    .write(activity, data, StringWriter)
```

In fact, there're 3 built-in writers for common usage
* `DefaultFileWriter.ByteArrayWriter` for byte array data
* `DefaultFileWriter.StringWriter` for string data
* `DefaultFileWriter.AnyWriter` for any serializable data